### PR TITLE
Ensure WP_List_Table dependency is loaded before custom table

### DIFF
--- a/pc-volontari-abruzzo.php
+++ b/pc-volontari-abruzzo.php
@@ -561,6 +561,9 @@ class PCV_Abruzzo_Plugin {
 /**
  * Custom WP_List_Table implementation for managing volunteers data
  */
+if ( ! class_exists( 'WP_List_Table' ) ) {
+    require_once ABSPATH . 'wp-admin/includes/class-wp-list-table.php';
+}
 if ( ! class_exists( 'PCV_List_Table' ) ) {
     class PCV_List_Table extends WP_List_Table {
         private $plugin;


### PR DESCRIPTION
## Summary
- load `WP_List_Table` before declaring `PCV_List_Table` to ensure dependency is available

## Testing
- `php -l pc-volontari-abruzzo.php`


------
https://chatgpt.com/codex/tasks/task_e_68c81f93a7ec832f91fd1bde8b2177ca