### PR TITLE
Use get_ip for reCAPTCHA remoteip

### DIFF
--- a/pc-volontari-abruzzo.php
+++ b/pc-volontari-abruzzo.php
@@ -220,7 +220,7 @@ class PCV_Abruzzo_Plugin {
                 'body' => [
                     'secret'   => $secret,
                     'response' => $token,
-                    'remoteip' => $_SERVER['REMOTE_ADDR'] ?? '',
+                    'remoteip' => $this->get_ip(),
                 ]
             ]);
             if ( is_wp_error($resp) ) $this->redirect_with_status('err');


### PR DESCRIPTION
## Summary
- call `get_ip()` when sending `remoteip` to reCAPTCHA

## Testing
- `php -l pc-volontari-abruzzo.php`
- `php -r 'function sanitize_text_field($s){return $s;} function get_ip(){foreach(["HTTP_CLIENT_IP","HTTP_X_FORWARDED_FOR","REMOTE_ADDR"] as $key){if(!empty($_SERVER[$key])){ $ip = explode(",", $_SERVER[$key])[0]; return sanitize_text_field($ip); }} return "";} $_SERVER["HTTP_X_FORWARDED_FOR"]="203.0.113.1, 70.41.3.18"; echo get_ip()."\n"; $_SERVER=[]; echo get_ip()."\n";'`
- `php -r 'function sanitize_text_field($s){return $s;} function get_ip(){foreach(["HTTP_CLIENT_IP","HTTP_X_FORWARDED_FOR","REMOTE_ADDR"] as $key){if(!empty($_SERVER[$key])){ $ip = explode(",", $_SERVER[$key])[0]; return sanitize_text_field($ip); }} return "";} $_SERVER["REMOTE_ADDR"]="198.51.100.42"; echo get_ip();'`

------
https://chatgpt.com/codex/tasks/task_e_68c824255878832fbea2827208f64ebd