### PR TITLE
Handle missing or invalid comuni data

### DIFF
--- a/pc-volontari-abruzzo.php
+++ b/pc-volontari-abruzzo.php
@@ -23,7 +23,23 @@ class PCV_Abruzzo_Plugin {
     private $comuni   = [];
 
     public function __construct() {
-        $data = json_decode( file_get_contents( __DIR__ . '/data/comuni_abruzzo.json' ), true );
+        $data = ['province' => [], 'comuni' => []];
+        $file = __DIR__ . '/data/comuni_abruzzo.json';
+        if ( file_exists( $file ) && is_readable( $file ) ) {
+            $json = file_get_contents( $file );
+            if ( $json !== false ) {
+                $decoded = json_decode( $json, true );
+                if ( json_last_error() === JSON_ERROR_NONE && is_array( $decoded ) ) {
+                    $data = $decoded;
+                } else {
+                    error_log( 'PCV_Abruzzo_Plugin: JSON decode error for comuni data - ' . json_last_error_msg() );
+                }
+            } else {
+                error_log( 'PCV_Abruzzo_Plugin: unable to read comuni data file' );
+            }
+        } else {
+            error_log( 'PCV_Abruzzo_Plugin: comuni data file missing or unreadable' );
+        }
         $this->province = $data['province'] ?? [];
         $this->comuni   = $data['comuni'] ?? [];
 


### PR DESCRIPTION
## Summary
- add file existence and readability checks for `comuni_abruzzo.json`
- log descriptive errors and fallback to empty data when JSON decoding fails

## Testing
- `php -l pc-volontari-abruzzo.php`
- `php test_harness.php` (normal file) *(temporary test harness)*
- `mv data/comuni_abruzzo.json data/comuni_abruzzo.json.bak && php test_harness.php` *(missing file test, then restored)*
- `mv data/comuni_abruzzo.json data/comuni_abruzzo.json.bak && echo '{invalid json' > data/comuni_abruzzo.json && php test_harness.php` *(corrupted JSON test, then restored)*

------
https://chatgpt.com/codex/tasks/task_e_68c82bbb466c832f86d838d51c0da1d3