### PR TITLE
Adjust admin toolbar layout styling

### DIFF
--- a/pc-volontari-abruzzo.php
+++ b/pc-volontari-abruzzo.php
@@ -322,7 +322,7 @@ class PCV_Abruzzo_Plugin {
 
     public function admin_assets($hook) {
         if ( strpos($hook, self::MENU_SLUG) === false ) return;
-        $css = ".pcv-topbar{display:flex;gap:10px;align-items:center;margin:12px 0}.pcv-topbar form{display:flex;gap:8px;align-items:center}";
+        $css = ".pcv-topbar{display:flex;gap:10px;align-items:center;margin:12px 0}.pcv-topbar form{display:flex;gap:8px;align-items:center}.wrap .tablenav{overflow:visible}.pcv-topbar, .pcv-topbar form{flex-wrap:wrap}";
         wp_register_style('pcv-admin-inline', false);
         wp_enqueue_style('pcv-admin-inline');
         wp_add_inline_style('pcv-admin-inline', $css);


### PR DESCRIPTION
## Summary
- extend the admin inline CSS rules to let the toolbar flex containers wrap and keep the table navigation visible

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68c82e803aa4832fbe7db9749c5717ec