### PR TITLE
Aggiorna documentazione su preferenze volontari

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Il form raccoglie i seguenti dati obbligatori:
 - Email e Telefono
 - Consenso privacy (obbligatorio)
 - Intenzione di partecipazione all'evento (opzionale)
+- Preferenze su pernottamento e pasti (opzionali)
 
 ## Privacy e GDPR
 
@@ -90,6 +91,7 @@ Il plugin crea la tabella `wp_pcv_volontari` con i seguenti campi:
 - `comune`, `provincia` - Località
 - `email`, `telefono` - Contatti
 - `privacy`, `partecipa` - Consensi
+- `dorme`, `mangia` - Preferenze pernottamento e pasti (opzionali)
 - `ip`, `user_agent` - Dati tecnici
 
 ## Personalizzazione Province e Comuni


### PR DESCRIPTION
## Summary
- documentate le preferenze opzionali su pernottamento e pasti tra i dati raccolti
- descritta la presenza delle colonne dorme e mangia nella tabella wp_pcv_volontari

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d24fd7483c832f9415b7e5da05884f