### PR TITLE
Reorganize optional checkboxes layout

### DIFF
--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -8,6 +8,9 @@
 .pcv-form label{font-weight:600;margin-bottom:6px}
 .pcv-form select,.pcv-form input[type=text],.pcv-form input[type=email],.pcv-form input[type=tel]{padding:10px;border:1px solid #dcdcdc;border-radius:6px}
 .pcv-form .pcv-checkbox{display:flex;gap:8px;align-items:flex-start;margin:8px 0}
+.pcv-form .pcv-checkbox-group{margin:16px 0;padding:12px 14px;border:1px solid #dcdcdc;border-radius:8px;display:flex;flex-direction:column;gap:8px;background-color:#f9f9f9}
+.pcv-form .pcv-checkbox-group .pcv-checkbox{margin:0}
+.pcv-form .pcv-checkbox-divider{border-top:1px solid #dcdcdc;margin:20px 0 16px}
 .pcv-form .pcv-submit{margin-top:8px}
 .pcv-alert{padding:10px;border-radius:6px;margin-bottom:12px}
 .pcv-alert.success{background:#e6ffed;border:1px solid #b7f0c3}

--- a/pc-volontari-abruzzo.php
+++ b/pc-volontari-abruzzo.php
@@ -237,24 +237,28 @@ class PCV_Abruzzo_Plugin {
                 </div>
             </div>
 
+            <div class="pcv-checkbox-group" role="group" aria-label="Opzioni facoltative">
+                <div class="pcv-checkbox">
+                    <input type="checkbox" id="pcv_partecipa" name="pcv_partecipa" value="1">
+                    <label for="pcv_partecipa">Sì, voglio partecipare all’evento</label>
+                </div>
+
+                <div class="pcv-checkbox">
+                    <input type="checkbox" id="pcv_dorme" name="pcv_dorme" value="1">
+                    <label for="pcv_dorme">Mi fermo a dormire</label>
+                </div>
+
+                <div class="pcv-checkbox">
+                    <input type="checkbox" id="pcv_mangia" name="pcv_mangia" value="1">
+                    <label for="pcv_mangia">Parteciperò ai pasti</label>
+                </div>
+            </div>
+
+            <div class="pcv-checkbox-divider" aria-hidden="true"></div>
+
             <div class="pcv-checkbox">
                 <input type="checkbox" id="pcv_privacy" name="pcv_privacy" value="1" required>
                 <label for="pcv_privacy">Ho letto e accetto l’Informativa Privacy *</label>
-            </div>
-
-            <div class="pcv-checkbox">
-                <input type="checkbox" id="pcv_partecipa" name="pcv_partecipa" value="1">
-                <label for="pcv_partecipa">Sì, voglio partecipare all’evento</label>
-            </div>
-
-            <div class="pcv-checkbox">
-                <input type="checkbox" id="pcv_dorme" name="pcv_dorme" value="1">
-                <label for="pcv_dorme">Mi fermo a dormire</label>
-            </div>
-
-            <div class="pcv-checkbox">
-                <input type="checkbox" id="pcv_mangia" name="pcv_mangia" value="1">
-                <label for="pcv_mangia">Parteciperò ai pasti</label>
             </div>
 
             <?php if ( $site_key ) : ?>


### PR DESCRIPTION
## Summary
- group the optional participation checkboxes together and move the privacy field after a new divider
- style the new checkbox container and divider to improve spacing and separation

## Testing
- php -l pc-volontari-abruzzo.php

------
https://chatgpt.com/codex/tasks/task_e_68d2522a1d00832fb9e6f84afaae9e2d