### PR TITLE
Ensure province/comune selects sync with localStorage

### DIFF
--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -59,12 +59,38 @@
     var storage = storageSafe();
     var storedProv = storage.get('pcv_provincia') || '';
     var storedComune = storage.get('pcv_comune') || '';
+    if (selComune) {
+      selComune.addEventListener('change', function(){
+        var comuneValue = selComune.value || '';
+        storage.set('pcv_comune', comuneValue);
+        storedComune = comuneValue;
+      });
+    }
+
     if (selProv) {
       fillProvince(selProv);
 
       selProv.addEventListener('change', function(){
-        fillComuni(selComune, selProv.value, null);
+        var newProv = selProv.value || '';
+        var previousProv = storedProv;
+        var shouldResetComune = (newProv !== previousProv) || !newProv;
+
+        fillComuni(selComune, newProv, shouldResetComune ? null : storedComune);
+
+        storage.set('pcv_provincia', newProv);
+        storedProv = newProv;
+
+        if (shouldResetComune) {
+          storedComune = '';
+          storage.set('pcv_comune', '');
+        }
+
         if (selComune) {
+          if (shouldResetComune) {
+            selComune.value = '';
+          } else if (storedComune) {
+            selComune.value = storedComune;
+          }
           selComune.dispatchEvent(new Event('change'));
         }
       });


### PR DESCRIPTION
## Summary
- persist the comune select value to storage whenever it changes and keep the in-memory state aligned
- update the province change handler to sync storage, reset comune state when needed, and dispatch the relevant events

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d25ab7aee8832f86018291deecfcb8