### PR TITLE
Fix translation domain usage in admin filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Tutte le modifiche rilevanti del plugin **PC Volontari Abruzzo**.
 
+## [1.0.2] - 2025-09-26
+### Correzioni
+- Risolto un errore fatale nell'interfaccia di amministrazione sostituendo riferimenti errati al dominio di traduzione nella tabella dei volontari.
+
 ## [1.0.1] - 2025-09-25
 ### Modifiche
 - Aggiornata la documentazione principale con panoramica completa delle funzionalità e delle procedure operative.

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Consulta il file [CHANGELOG.md](CHANGELOG.md) per lo storico completo delle vers
 
 ## Versione
 
-Attuale: **1.0.1**
+Attuale: **1.0.2**
 
 ## Build e distribuzione
 

--- a/languages/README.md
+++ b/languages/README.md
@@ -1,0 +1,11 @@
+# Traduzioni del plugin
+
+Il plugin carica automaticamente i file di traduzione dal percorso `languages/` utilizzando il dominio `pc-volontari-abruzzo`.
+
+Per generare i file `.po`/`.mo` aggiornati puoi utilizzare [WP-CLI](https://developer.wordpress.org/cli/commands/i18n/make-pot/):
+
+```bash
+wp i18n make-pot . languages/pc-volontari-abruzzo.pot
+```
+
+Successivamente crea i file locali (es. `pc-volontari-abruzzo-it_IT.po`) con un editor di traduzioni come [Poedit](https://poedit.net/).

--- a/pc-volontari-abruzzo.php
+++ b/pc-volontari-abruzzo.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: PC Volontari Abruzzo
  * Description: Raccolta iscrizioni volontari (Protezione Civile Abruzzo) con form via shortcode, popup comune, lista completa Comuni/Province Abruzzo, reCAPTCHA v2 e gestionale backend.
- * Version: 1.0.1
+ * Version: 1.0.2
  * Author: Francesco Passeri
  * Author URI: https://francescopasseri.com
  * License: GPLv2 or later
@@ -13,7 +13,7 @@ if ( ! defined('ABSPATH') ) exit;
 
 class PCV_Abruzzo_Plugin {
 
-    const VERSION   = '1.0.1';
+    const VERSION   = '1.0.2';
     const TEXT_DOMAIN = 'pc-volontari-abruzzo';
     const TABLE     = 'pcv_volontari';
     const NONCE     = 'pcv_form_nonce';
@@ -945,9 +945,9 @@ if ( ! class_exists( 'PCV_List_Table' ) ) {
             echo '<div class="pcv-topbar"><form method="get">';
             echo '<input type="hidden" name="page" value="'.esc_attr(PCV_Abruzzo_Plugin::MENU_SLUG).'">';
 
-            echo '<label class="screen-reader-text" for="pcv-admin-provincia">' . esc_html__( 'Filtra per Provincia', self::TEXT_DOMAIN ) . '</label>';
+            echo '<label class="screen-reader-text" for="pcv-admin-provincia">' . esc_html__( 'Filtra per Provincia', PCV_Abruzzo_Plugin::TEXT_DOMAIN ) . '</label>';
             echo '<select name="f_prov" id="pcv-admin-provincia">';
-            echo '<option value="">' . esc_html__( 'Tutte le province', self::TEXT_DOMAIN ) . '</option>';
+            echo '<option value="">' . esc_html__( 'Tutte le province', PCV_Abruzzo_Plugin::TEXT_DOMAIN ) . '</option>';
             foreach ($province as $code => $label) {
                 $selected_attr = selected( $f_prov, $code, false );
                 $option_label = sprintf( '%s (%s)', $label, $code );
@@ -955,20 +955,20 @@ if ( ! class_exists( 'PCV_List_Table' ) ) {
             }
             echo '</select>';
 
-            echo '<label class="screen-reader-text" for="pcv-admin-comune">' . esc_html__( 'Filtra per Comune', self::TEXT_DOMAIN ) . '</label>';
+            echo '<label class="screen-reader-text" for="pcv-admin-comune">' . esc_html__( 'Filtra per Comune', PCV_Abruzzo_Plugin::TEXT_DOMAIN ) . '</label>';
             echo '<select name="f_comune" id="pcv-admin-comune" data-selected="'.esc_attr($f_comune).'">';
-            echo '<option value="">' . esc_html__( 'Tutti i comuni', self::TEXT_DOMAIN ) . '</option>';
+            echo '<option value="">' . esc_html__( 'Tutti i comuni', PCV_Abruzzo_Plugin::TEXT_DOMAIN ) . '</option>';
             foreach ($comuni_options as $comune_name) {
                 $selected_attr = selected( $f_comune, $comune_name, false );
                 echo '<option value="'.esc_attr($comune_name).'"'.$selected_attr.'>'.esc_html($comune_name).'</option>';
             }
             echo '</select>';
 
-            echo '<input type="search" name="s" value="'.esc_attr($s).'" placeholder="' . esc_attr__( 'Cerca…', self::TEXT_DOMAIN ) . '">';
-            submit_button( __( 'Filtra', self::TEXT_DOMAIN ), 'secondary', '', false );
-            echo ' <a href="'.esc_url($url_no_vars).'" class="button">' . esc_html__( 'Pulisci', self::TEXT_DOMAIN ) . '</a> ';
+            echo '<input type="search" name="s" value="'.esc_attr($s).'" placeholder="' . esc_attr__( 'Cerca…', PCV_Abruzzo_Plugin::TEXT_DOMAIN ) . '">';
+            submit_button( __( 'Filtra', PCV_Abruzzo_Plugin::TEXT_DOMAIN ), 'secondary', '', false );
+            echo ' <a href="'.esc_url($url_no_vars).'" class="button">' . esc_html__( 'Pulisci', PCV_Abruzzo_Plugin::TEXT_DOMAIN ) . '</a> ';
             $export_url = wp_nonce_url( add_query_arg(['pcv_export'=>'csv'], admin_url('admin.php?page='.PCV_Abruzzo_Plugin::MENU_SLUG) ), 'pcv_export' );
-            echo ' <a class="button button-primary" href="'.esc_url($export_url).'">' . esc_html__( 'Export CSV', self::TEXT_DOMAIN ) . '</a>';
+            echo ' <a class="button button-primary" href="'.esc_url($export_url).'">' . esc_html__( 'Export CSV', PCV_Abruzzo_Plugin::TEXT_DOMAIN ) . '</a>';
             echo '</form></div>';
         }
     }


### PR DESCRIPTION
## Summary
- fix the translation domain references used in the admin filter UI to avoid runtime errors
- bump the plugin version to 1.0.2 and document the change in the changelog and README
- add a README under `languages/` to clarify how to generate translation files

## Testing
- php -l pc-volontari-abruzzo.php

------
https://chatgpt.com/codex/tasks/task_e_68d515050688832f88297e9dc408e667