### PR TITLE
Add notification emails for volunteer registrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 Tutte le modifiche rilevanti del plugin **PC Volontari Abruzzo**.
 
+## [1.1.0] - 2025-09-30
+### Novità
+- Aggiunta la possibilità di inviare notifiche email configurabili ai referenti quando viene registrato un nuovo volontario.
+- Introdotto un hook (`pcv_volunteer_registered`) per integrare workflow personalizzati dopo il salvataggio dei dati.
+### Miglioramenti
+- Sanitizzazione avanzata dell'User Agent memorizzato con ogni iscrizione.
+
 ## [1.0.2] - 2025-09-26
 ### Correzioni
 - Risolto un errore fatale nell'interfaccia di amministrazione sostituendo riferimenti errati al dominio di traduzione nella tabella dei volontari.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Plugin WordPress per la raccolta delle iscrizioni dei volontari della Protezione
 - Esportazione CSV dei dati raccolti.
 - Configurazione reCAPTCHA dall'interfaccia admin.
 - Personalizzazione delle etichette principali del form.
+- Notifiche email configurabili per avvisare i referenti ad ogni nuova iscrizione.
 - Gestione completa degli stati della tabella (paginazione, ordinamento, ricerca libera).
 
 ## Architettura del plugin
@@ -77,6 +78,11 @@ La disinstallazione del plugin rimuove la tabella dei volontari e le opzioni di 
 3. Copia Site Key e Secret Key.
 4. In WordPress vai su **Volontari Abruzzo → Impostazioni**.
 5. Inserisci le chiavi e salva.
+
+### Notifiche email
+- Attiva l'opzione **Notifiche email** per ricevere un avviso ad ogni nuova iscrizione.
+- Inserisci uno o più destinatari separati da invio, virgola o punto e virgola (se vuoto verrà usata l'email amministratore di WordPress).
+- Personalizza l'oggetto dell'email per riconoscere rapidamente le comunicazioni in arrivo.
 
 ### Personalizzazione del form
 - Modifica le etichette e i testi direttamente dall'interfaccia admin.
@@ -135,7 +141,7 @@ Consulta il file [CHANGELOG.md](CHANGELOG.md) per lo storico completo delle vers
 
 ## Versione
 
-Attuale: **1.0.2**
+Attuale: **1.1.0**
 
 ## Build e distribuzione
 


### PR DESCRIPTION
## Summary
- add configurable notification emails for each new volunteer registration and send via wp_mail
- extend admin settings with notification toggles, recipient list, and subject customization
- sanitize stored user agent values and expose a hook after successful registrations

## Testing
- php -l pc-volontari-abruzzo.php

------
https://chatgpt.com/codex/tasks/task_e_68d517485dc8832fb2f524821f15adb2