### PR TITLE
Refactor WordPress zip build workflow

### DIFF
--- a/.github/workflows/build-wordpress-zip.yml
+++ b/.github/workflows/build-wordpress-zip.yml
@@ -9,135 +9,197 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Plugin version (optional - will use git tag or commit hash)'
+        description: 'Plugin version (optional - overrides detected version)'
         required: false
         type: string
 
 jobs:
   build-zip:
     runs-on: ubuntu-latest
-    
+    env:
+      PLUGIN_NAME: pc-volontari-abruzzo
+      BUILD_ROOT: build
+      PLUGIN_MAIN_FILE: pc-volontari-abruzzo.php
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      zip-name: ${{ steps.archive.outputs['zip-name'] }}
+      zip-path: ${{ steps.archive.outputs['zip-path'] }}
+      tagged-release: ${{ steps.version.outputs['tagged-release'] }}
+
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-      
-    - name: Get version information
-      id: version
-      run: |
-        # Determine version based on input, git tag, or commit
-        if [ -n "${{ github.event.inputs.version }}" ]; then
-          VERSION="${{ github.event.inputs.version }}"
-        elif [[ $GITHUB_REF == refs/tags/* ]]; then
-          VERSION=${GITHUB_REF#refs/tags/}
-        else
-          VERSION="dev-$(echo $GITHUB_SHA | cut -c1-8)"
-        fi
-        echo "version=$VERSION" >> $GITHUB_OUTPUT
-        echo "Plugin version: $VERSION"
-        
-    - name: Prepare plugin directory
-      run: |
-        # Create temporary build directory
-        mkdir -p build
-        PLUGIN_NAME="pc-volontari-abruzzo"
-        PLUGIN_DIR="build/$PLUGIN_NAME"
-        
-        # Copy plugin files to build directory
-        mkdir -p "$PLUGIN_DIR"
-        
-        # Copy main plugin file
-        cp pc-volontari-abruzzo.php "$PLUGIN_DIR/"
-        
-        # Copy assets directory
-        cp -r assets "$PLUGIN_DIR/"
-        
-        # Copy data directory
-        cp -r data "$PLUGIN_DIR/"
-        
-        # Copy README
-        cp README.md "$PLUGIN_DIR/"
-        
-        # Create plugin info file
-        echo "Plugin: PC Volontari Abruzzo" > "$PLUGIN_DIR/plugin-info.txt"
-        echo "Version: ${{ steps.version.outputs.version }}" >> "$PLUGIN_DIR/plugin-info.txt"
-        echo "Build Date: $(date)" >> "$PLUGIN_DIR/plugin-info.txt"
-        echo "Build Commit: $GITHUB_SHA" >> "$PLUGIN_DIR/plugin-info.txt"
-        
-        echo "PLUGIN_DIR=$PLUGIN_DIR" >> $GITHUB_ENV
-        echo "PLUGIN_NAME=$PLUGIN_NAME" >> $GITHUB_ENV
-        
-    - name: Update plugin version in main file
-      run: |
-        # Update version in plugin header if this is a tagged release
-        if [[ $GITHUB_REF == refs/tags/* ]]; then
-          sed -i "s/Version: 1.0/Version: ${{ steps.version.outputs.version }}/" "$PLUGIN_DIR/pc-volontari-abruzzo.php"
-          sed -i "s/const VERSION   = '1.0';/const VERSION   = '${{ steps.version.outputs.version }}';/" "$PLUGIN_DIR/pc-volontari-abruzzo.php"
-        fi
-        
-    - name: Validate plugin structure
-      run: |
-        echo "=== Plugin Directory Structure ==="
-        find "$PLUGIN_DIR" -type f | sort
-        echo ""
-        echo "=== Plugin Main File Header ==="
-        head -10 "$PLUGIN_DIR/pc-volontari-abruzzo.php"
-        
-    - name: Create ZIP archive
-      run: |
-        cd build
-        ZIP_NAME="${PLUGIN_NAME}-${{ steps.version.outputs.version }}.zip"
-        zip -r "$ZIP_NAME" "$PLUGIN_NAME"
-        
-        # Verify ZIP contents
-        echo "=== ZIP Contents ==="
-        unzip -l "$ZIP_NAME"
-        
-        echo "ZIP_NAME=$ZIP_NAME" >> $GITHUB_ENV
-        echo "ZIP_PATH=build/$ZIP_NAME" >> $GITHUB_ENV
-        
-    - name: Upload ZIP as artifact
-      uses: actions/upload-artifact@v4
-      with:
-        name: wordpress-plugin-${{ steps.version.outputs.version }}
-        path: ${{ env.ZIP_PATH }}
-        retention-days: 30
-        
-    - name: Upload to release (if tagged)
-      if: startsWith(github.ref, 'refs/tags/')
-      uses: softprops/action-gh-release@v1
-      with:
-        files: ${{ env.ZIP_PATH }}
-        name: PC Volontari Abruzzo ${{ steps.version.outputs.version }}
-        body: |
-          WordPress Plugin: PC Volontari Abruzzo
-          Version: ${{ steps.version.outputs.version }}
-          
-          ## Installation
-          1. Download the ZIP file
-          2. Go to WordPress Admin → Plugins → Add New → Upload Plugin
-          3. Upload the ZIP file and activate the plugin
-          
-          ## Files included
-          - Main plugin file: `pc-volontari-abruzzo.php`
-          - Frontend assets: `assets/css/frontend.css`, `assets/js/frontend.js`
-          - Municipality data: `data/comuni_abruzzo.json`
-          - Documentation: `README.md`
-        draft: false
-        prerelease: false
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        
-    - name: Build summary
-      run: |
-        echo "## Build Complete! 🎉" >> $GITHUB_STEP_SUMMARY
-        echo "" >> $GITHUB_STEP_SUMMARY
-        echo "**Plugin:** PC Volontari Abruzzo" >> $GITHUB_STEP_SUMMARY
-        echo "**Version:** ${{ steps.version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
-        echo "**ZIP File:** ${{ env.ZIP_NAME }}" >> $GITHUB_STEP_SUMMARY
-        echo "**Size:** $(ls -lh ${{ env.ZIP_PATH }} | awk '{print $5}')" >> $GITHUB_STEP_SUMMARY
-        echo "" >> $GITHUB_STEP_SUMMARY
-        echo "The WordPress plugin ZIP is available as an artifact and can be downloaded from the Actions page." >> $GITHUB_STEP_SUMMARY
-        if [[ $GITHUB_REF == refs/tags/* ]]; then
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "🏷️ **Release created:** This ZIP has also been attached to the GitHub release." >> $GITHUB_STEP_SUMMARY
-        fi
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Determine build version
+        id: version
+        shell: bash
+        run: |
+          set -eo pipefail
+
+          HEADER_VERSION=$(awk -F': ' '/^\s*\*\s*Version/ {print $2; exit}' "$PLUGIN_MAIN_FILE" | tr -d '\r')
+          if [ -z "$HEADER_VERSION" ]; then
+            HEADER_VERSION="0.0.0"
+          fi
+
+          INPUT_VERSION="${{ github.event.inputs.version }}"
+          VERSION="${HEADER_VERSION}-dev+$(git rev-parse --short HEAD)"
+          SHOULD_UPDATE="false"
+          TAGGED="false"
+
+          if [ -n "$INPUT_VERSION" ]; then
+            VERSION="$INPUT_VERSION"
+            SHOULD_UPDATE="true"
+          elif [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            VERSION="${GITHUB_REF#refs/tags/}"
+            SHOULD_UPDATE="true"
+            TAGGED="true"
+          fi
+
+          echo "Detected plugin header version: $HEADER_VERSION"
+          echo "Resolved build version: $VERSION"
+
+          {
+            echo "version=$VERSION"
+            echo "base-version=$HEADER_VERSION"
+            echo "should-update=$SHOULD_UPDATE"
+            echo "tagged-release=$TAGGED"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Prepare plugin workspace
+        id: workspace
+        shell: bash
+        run: |
+          set -eo pipefail
+
+          rm -rf "$BUILD_ROOT"
+          PLUGIN_DIR="$BUILD_ROOT/$PLUGIN_NAME"
+          mkdir -p "$PLUGIN_DIR"
+
+          INCLUDE_PATHS=(
+            "$PLUGIN_MAIN_FILE"
+            "README.md"
+            "CHANGELOG.md"
+            "assets"
+            "data"
+            "languages"
+          )
+
+          for path in "${INCLUDE_PATHS[@]}"; do
+            if [ -e "$path" ]; then
+              rsync -a "$path" "$PLUGIN_DIR/"
+            else
+              echo "::warning::Skipping missing path '$path'"
+            fi
+          done
+
+          VERSION="${{ steps.version.outputs.version }}"
+          BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+          cat > "$PLUGIN_DIR/plugin-info.txt" <<INFO
+Plugin: PC Volontari Abruzzo
+Version: $VERSION
+Build Date: $BUILD_DATE
+Build Commit: ${GITHUB_SHA}
+Source Ref: ${GITHUB_REF}
+Built With: GitHub Actions
+INFO
+
+          {
+            echo "PLUGIN_DIR=$PLUGIN_DIR"
+            echo "PLUGIN_VERSION=$VERSION"
+          } >> "$GITHUB_ENV"
+
+      - name: Update plugin version metadata
+        if: steps.version.outputs['should-update'] == 'true'
+        shell: bash
+        run: |
+          set -eo pipefail
+
+          PLUGIN_DIR="$BUILD_ROOT/$PLUGIN_NAME"
+          MAIN_FILE="$PLUGIN_DIR/$PLUGIN_MAIN_FILE"
+          VERSION="${{ steps.version.outputs.version }}"
+
+          perl -0pi -e 's/(Version:\s*).*/${1}'"$VERSION"'/' "$MAIN_FILE"
+          perl -0pi -e "s/(const\\s+VERSION\\s*=\\s*')[^']+(';)/\1$VERSION\2/" "$MAIN_FILE"
+
+      - name: Validate plugin contents
+        shell: bash
+        run: |
+          set -eo pipefail
+
+          echo "=== Plugin Directory Structure ==="
+          find "$BUILD_ROOT/$PLUGIN_NAME" -type f | sort
+          echo
+          echo "=== Plugin Main File Header ==="
+          head -n 15 "$BUILD_ROOT/$PLUGIN_NAME/$PLUGIN_MAIN_FILE"
+
+      - name: Create distributable ZIP
+        id: archive
+        shell: bash
+        run: |
+          set -eo pipefail
+
+          ZIP_NAME="$PLUGIN_NAME-${{ steps.version.outputs.version }}.zip"
+          cd "$BUILD_ROOT"
+          zip -rq "$ZIP_NAME" "$PLUGIN_NAME"
+          cd - > /dev/null
+
+          ZIP_PATH="$BUILD_ROOT/$ZIP_NAME"
+          echo "=== ZIP Contents ==="
+          unzip -l "$ZIP_PATH"
+
+          {
+            echo "zip-name=$ZIP_NAME"
+            echo "zip-path=$ZIP_PATH"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Upload ZIP as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.PLUGIN_NAME }}-${{ steps.version.outputs.version }}
+          path: ${{ steps.archive.outputs['zip-path'] }}
+          retention-days: 30
+
+      - name: Upload to release (if tagged)
+        if: steps.version.outputs['tagged-release'] == 'true'
+        uses: softprops/action-gh-release@v1
+        with:
+          files: ${{ steps.archive.outputs['zip-path'] }}
+          name: PC Volontari Abruzzo ${{ steps.version.outputs.version }}
+          body: |
+            WordPress Plugin: PC Volontari Abruzzo
+            Version: ${{ steps.version.outputs.version }}
+
+            ## Installation
+            1. Download the ZIP file
+            2. Go to WordPress Admin → Plugins → Add New → Upload Plugin
+            3. Upload the ZIP file and activate the plugin
+
+            ## Files included
+            - Main plugin file: `pc-volontari-abruzzo.php`
+            - Frontend assets: `assets/css/frontend.css`, `assets/js/frontend.js`
+            - Municipality data: `data/comuni_abruzzo.json`
+            - Translations: files under `languages/`
+            - Documentation: `README.md`, `CHANGELOG.md`
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build summary
+        shell: bash
+        run: |
+          ZIP_PATH="${{ steps.archive.outputs['zip-path'] }}"
+          ZIP_NAME="${{ steps.archive.outputs['zip-name'] }}"
+          VERSION="${{ steps.version.outputs.version }}"
+
+          echo "## Build Complete! 🎉" >> "$GITHUB_STEP_SUMMARY"
+          echo >> "$GITHUB_STEP_SUMMARY"
+          echo "**Plugin:** PC Volontari Abruzzo" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Version:** $VERSION" >> "$GITHUB_STEP_SUMMARY"
+          echo "**ZIP File:** $ZIP_NAME" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Size:** $(ls -lh "$ZIP_PATH" | awk '{print $5}')" >> "$GITHUB_STEP_SUMMARY"
+          echo >> "$GITHUB_STEP_SUMMARY"
+          echo "The WordPress plugin ZIP is available as an artifact and can be downloaded from the Actions page." >> "$GITHUB_STEP_SUMMARY"
+          if [ "${{ steps.version.outputs['tagged-release'] }}" == "true" ]; then
+            echo >> "$GITHUB_STEP_SUMMARY"
+            echo "🏷️ **Release created:** This ZIP has also been attached to the GitHub release." >> "$GITHUB_STEP_SUMMARY"
+          fi


### PR DESCRIPTION
## Summary
- refactor the WordPress plugin packaging workflow to centralize plugin metadata and build settings
- add structured version detection, workspace preparation, and archive outputs for reuse in later steps
- extend the release notes and artifact handling to include translations and changelog files

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d5308b61f0832fac616351de3318b0